### PR TITLE
Fixes for ElasticSearch service

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -144,10 +144,12 @@ class AWS4Auth(AuthBase):
         """
         if hasattr(req, 'body') and req.body is not None:
             self.encode_body(req)
+            content_hash = hashlib.sha256(req.body)
         else:
-            req.body = b''
-        content_hash = hashlib.sha256(req.body)
+            content_hash = hashlib.sha256(b'')
+
         req.headers['x-amz-content-sha256'] = content_hash.hexdigest()
+
         if 'X-Amz-Date' not in req.headers:
             timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
             req.headers['X-Amz-Date'] = timestamp

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -251,7 +251,7 @@ class AWS4Auth(AuthBase):
         # in the signed headers, but Requests doesn't include it in a
         # PreparedRequest
         if 'host' not in headers:
-            headers['host'] = urlparse(req.url).netloc
+            headers['host'] = urlparse(req.url).netloc.split(':')[0]
         # Aggregate for upper/lowercase header name collisions in header names,
         # AMZ requires values of colliding headers be concatenated into a
         # single header with lowercase name.  Although this is not possible with


### PR DESCRIPTION
AWS recently launched a hosted ElasticSearch service that uses IAM to authenticate HTTP requests. I've made two small tweaks that will let you plug this into the [official python elasticsearch library](https://github.com/elastic/elasticsearch-py) and easily authenticate with IAM. Here's an example of how this works:

``` python
import elasticsearch

host = 'YOURHOST.us-east-1.es.amazonaws.com'
awsauth = AWS4Auth(creds.access_key, creds.secret_key, region, 'es')

es = elasticsearch.Elasticsearch(hosts=[{'host': host, 'port': 443}],
                                             http_auth=awsauth,
                                             use_ssl=True,
                                             verify_certs=True,
                                             connection_class=elasticsearch.connection.RequestsHttpConnection)
print es.cluster.health()
```

If you're interested, I have a wrapper I'm using to load my IAM role and inject the token. It would be pretty handy if your library could do that out of the box, though!
