### PR TITLE
Fixing bug where x-amz-date does not match the date in Credential at day boundaries.

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -148,13 +148,15 @@ class AWS4Auth(AuthBase):
             req.body = b''
         content_hash = hashlib.sha256(req.body)
         req.headers['x-amz-content-sha256'] = content_hash.hexdigest()
-        if 'X-Amz-Date' not in req.headers:
-            timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
-            req.headers['X-Amz-Date'] = timestamp
+        now = datetime.utcnow()
+        if 'x-amz-date' not in req.headers:
+            timestamp = now.strftime('%Y%m%dT%H%M%SZ')
+            req.headers['x-amz-date'] = timestamp
         result = self.get_canonical_headers(req, self.include_hdrs)
         cano_headers, signed_headers = result
         cano_req = self.get_canonical_request(req, cano_headers,
                                               signed_headers)
+        self.signing_key.set_date(now.strftime('%Y%m%d'))
         sig_string = self.get_sig_string(req, cano_req, self.signing_key.scope)
         sig_string = sig_string.encode('utf-8')
         hsh = hmac.new(self.signing_key.key, sig_string, hashlib.sha256)

--- a/requests_aws4auth/aws4signingkey.py
+++ b/requests_aws4auth/aws4signingkey.py
@@ -65,13 +65,8 @@ class AWS4SigningKey:
 
         self.region = region
         self.service = service
-        self.amz_date = date or datetime.utcnow().strftime('%Y%m%d')
-        self.scope = '{}/{}/{}/aws4_request'.format(
-                                            self.amz_date,
-                                            self.region,
-                                            self.service)
-        self.key = self.generate_key(access_key, self.region,
-                                     self.service, self.amz_date)
+        self.access_key = access_key
+        self.set_date(date or datetime.utcnow().strftime('%Y%m%d'))
 
     @classmethod
     def generate_key(cls, access_key, region, service, amz_date,
@@ -111,3 +106,24 @@ class AWS4SigningKey:
         if isinstance(msg, text_type):
             msg = msg.encode('utf-8')
         return hmac.new(key, msg, hashlib.sha256).digest()
+
+
+    def set_date(self, date):
+        """
+        Allows seting new date for this instance of AWS4SigningKey.
+
+        date       -- 8-digit date of the form YYYYMMDD. This is the starting
+                      date for the signing key's validity, signing keys are
+                      valid for 7 days from this date.  If date is not supplied
+                      the current date is used.
+        """
+
+
+        self.amz_date = date
+        self.scope = '{}/{}/{}/aws4_request'.format(
+                                            self.amz_date,
+                                            self.region,
+                                            self.service)
+        self.key = self.generate_key(self.access_key, self.region,
+                                     self.service, self.amz_date)
+


### PR DESCRIPTION
The bug is that the timestamp for the signing key is generated when the object is instantiated. Once we cross a date boundary it seems AWS requires that the signing key's scope date match the x-amz-date header. The solution I propose is to continually set the current date for the signing key to match the x-amz-date header.
