### PR TITLE
Quote paths

### DIFF
--- a/requests_aws4auth/__init__.py
+++ b/requests_aws4auth/__init__.py
@@ -148,4 +148,4 @@ from .aws4signingkey import AWS4SigningKey
 del aws4auth
 del aws4signingkey
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'

--- a/requests_aws4auth/__init__.py
+++ b/requests_aws4auth/__init__.py
@@ -148,4 +148,4 @@ from .aws4signingkey import AWS4SigningKey
 del aws4auth
 del aws4signingkey
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'

--- a/requests_aws4auth/__init__.py
+++ b/requests_aws4auth/__init__.py
@@ -148,4 +148,4 @@ from .aws4signingkey import AWS4SigningKey
 del aws4auth
 del aws4signingkey
 
-__version__ = '0.6'
+__version__ = '0.6.1'

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -313,7 +313,7 @@ class AWS4Auth(AuthBase):
         if path.endswith('/') and not fixed_path.endswith('/'):
             fixed_path += '/'
         full_path = fixed_path
-        full_path = quote(full_path)
+        full_path = quote(full_path, safe='/~')
         if qs:
             full_path = '?'.join((full_path, qs))
         return full_path

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -313,6 +313,7 @@ class AWS4Auth(AuthBase):
         if path.endswith('/') and not fixed_path.endswith('/'):
             fixed_path += '/'
         full_path = fixed_path
+        full_path = quote(full_path)
         if qs:
             full_path = '?'.join((full_path, qs))
         return full_path


### PR DESCRIPTION
While making some requests to AWS ElasticSearch, I've discovered that whenever '%' characters were included in the URLs, the signing would fail. This commit should fix it.
