### PR TITLE
Optionally add x-amz-security-token header for temporary STS credentials

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -239,6 +239,7 @@ class AWS4Auth(AuthBase):
 
         self.include_hdrs = kwargs.get('include_hdrs',
                                        self.default_include_headers)
+        self.sessionToken = kwargs.get('session_token')
         AuthBase.__init__(self)
 
     def regenerate_signing_key(self, secret_key=None, region=None,
@@ -324,6 +325,8 @@ class AWS4Auth(AuthBase):
         else:
             content_hash = hashlib.sha256(b'')
         req.headers['x-amz-content-sha256'] = content_hash.hexdigest()
+        if self.sessionToken:
+            req.headers['x-amz-security-token'] = self.sessionToken
 
         # generate signature
         result = self.get_canonical_headers(req, self.include_hdrs)


### PR DESCRIPTION
I've updated to add x-amz-security-token header from an optional constructor kwarg -- necessary in order to use in an AWS Lambda with IAM role-based auth. 

I'm very new to AWS, so it's very possible I've missed some use cases, but this change works for me.

Sorry, I didn't have time yet to update the doc or tests. 
