### PR TITLE
unicode ssl errors

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -172,7 +172,7 @@ class AWS4Auth(AuthBase):
                             supplied directly on the command line
 
     """
-    default_include_headers = ['host', 'content-type', 'date', 'x-amz-*']
+    default_include_headers = [b'host', b'content-type', b'date', b'x-amz-*']
 
     def __init__(self, *args, **kwargs):
         """
@@ -256,7 +256,7 @@ class AWS4Auth(AuthBase):
 
         self.session_token = kwargs.get('session_token')
         if self.session_token:
-            self.default_include_headers.append('x-amz-security-token')
+            self.default_include_headers.append(b'x-amz-security-token')
         self.include_hdrs = kwargs.get('include_hdrs',
                                        self.default_include_headers)
         AuthBase.__init__(self)
@@ -328,11 +328,11 @@ class AWS4Auth(AuthBase):
         if req_date is None:
             # no date headers or none in recognisable format
             # replace them with x-amz-header with current date and time
-            if 'date' in req.headers: del req.headers['date']
-            if 'x-amz-date' in req.headers: del req.headers['x-amz-date']
+            if b'date' in req.headers: del req.headers[b'date']
+            if b'x-amz-date' in req.headers: del req.headers[b'x-amz-date']
             now = datetime.datetime.utcnow()
             req_date = now.date()
-            req.headers['x-amz-date'] = now.strftime('%Y%m%dT%H%M%SZ')
+            req.headers[b'x-amz-date'] = now.strftime('%Y%m%dT%H%M%SZ')
         req_scope_date = req_date.strftime('%Y%m%d')
         if req_scope_date != self.date:
             self.handle_date_mismatch(req)
@@ -343,9 +343,9 @@ class AWS4Auth(AuthBase):
             content_hash = hashlib.sha256(req.body)
         else:
             content_hash = hashlib.sha256(b'')
-        req.headers['x-amz-content-sha256'] = content_hash.hexdigest()
+        req.headers[b'x-amz-content-sha256'] = content_hash.hexdigest()
         if self.session_token:
-            req.headers['x-amz-security-token'] = self.session_token
+            req.headers[b'x-amz-security-token'] = self.session_token
 
         # generate signature
         result = self.get_canonical_headers(req, self.include_hdrs)
@@ -361,7 +361,7 @@ class AWS4Auth(AuthBase):
                                                 self.signing_key.scope)
         auth_str += 'SignedHeaders={}, '.format(signed_headers)
         auth_str += 'Signature={}'.format(sig)
-        req.headers['Authorization'] = auth_str
+        req.headers[b'Authorization'] = bytes(auth_str)
         return req
 
     @classmethod
@@ -377,7 +377,7 @@ class AWS4Auth(AuthBase):
 
         """
         date = None
-        for header in ['x-amz-date', 'date']:
+        for header in [b'x-amz-date', b'date']:
             if header not in req.headers:
                 continue
             try:
@@ -480,7 +480,7 @@ class AWS4Auth(AuthBase):
 
         """
         if isinstance(req.body, text_type):
-            split = req.headers.get('content-type', 'text/plain').split(';')
+            split = req.headers.get(b'content-type', b'text/plain').split(';')
             if len(split) == 2:
                 ct, cs = split
                 cs = cs.split('=')[1]

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -29,6 +29,12 @@ from .aws4signingkey import AWS4SigningKey
 from .exceptions import DateMismatchError, NoSecretKeyError, DateFormatError
 
 
+def makebytes(value):
+    if not isinstance(value, bytes):
+        value = value.encode('ascii')
+    return value
+
+
 class AWS4Auth(AuthBase):
     """
     Requests authentication class providing AWS version 4 authentication for
@@ -361,7 +367,7 @@ class AWS4Auth(AuthBase):
                                                 self.signing_key.scope)
         auth_str += 'SignedHeaders={}, '.format(signed_headers)
         auth_str += 'Signature={}'.format(sig)
-        req.headers[b'Authorization'] = bytes(auth_str)
+        req.headers[b'Authorization'] = makebytes(auth_str)
         return req
 
     @classmethod
@@ -480,19 +486,19 @@ class AWS4Auth(AuthBase):
 
         """
         if isinstance(req.body, text_type):
-            split = req.headers.get(b'content-type', b'text/plain').split(';')
+            split = req.headers.get(b'content-type', b'text/plain').split(b';')
             if len(split) == 2:
                 ct, cs = split
-                cs = cs.split('=')[1]
+                cs = cs.split(b'=')[1]
                 req.body = req.body.encode(cs)
             else:
                 ct = split[0]
-                if (ct == 'application/x-www-form-urlencoded' or
-                        'x-amz-' in ct):
+                if (ct == b'application/x-www-form-urlencoded' or
+                        b'x-amz-' in ct):
                     req.body = req.body.encode()
                 else:
                     req.body = req.body.encode('utf-8')
-                    req.headers['content-type'] = ct + '; charset=utf-8'
+                    req.headers[b'content-type'] = ct + b'; charset=utf-8'
 
     def get_canonical_request(self, req, cano_headers, signed_headers):
         """
@@ -510,13 +516,13 @@ class AWS4Auth(AuthBase):
         path = self.amz_cano_path(url.path)
         # AWS handles "extreme" querystrings differently to urlparse
         # (see post-vanilla-query-nonunreserved test in aws_testsuite)
-        split = req.url.split('?', 1)
-        qs = split[1] if len(split) == 2 else ''
+        split = req.url.split(b'?', 1)
+        qs = split[1] if len(split) == 2 else b''
         qs = self.amz_cano_querystring(qs)
-        payload_hash = req.headers['x-amz-content-sha256']
+        payload_hash = req.headers[b'x-amz-content-sha256']
         req_parts = [req.method.upper(), path, qs, cano_headers,
                      signed_headers, payload_hash]
-        cano_req = '\n'.join(req_parts)
+        cano_req = b'\n'.join(req_parts)
         return cano_req
 
     @classmethod
@@ -545,8 +551,8 @@ class AWS4Auth(AuthBase):
         # Temporarily include the host header - AWS requires it to be included
         # in the signed headers, but Requests doesn't include it in a
         # PreparedRequest
-        if 'host' not in headers:
-            headers['host'] = urlparse(req.url).netloc.split(':')[0]
+        if b'host' not in headers:
+            headers[b'host'] = urlparse(req.url).netloc.split(':')[0]
         # Aggregate for upper/lowercase header name collisions in header names,
         # AMZ requires values of colliding headers be concatenated into a
         # single header with lowercase name.  Although this is not possible with
@@ -554,22 +560,22 @@ class AWS4Auth(AuthBase):
         # is here just in case you duck type with a regular dict
         cano_headers_dict = {}
         for hdr, val in headers.items():
-            hdr = hdr.strip().lower()
-            val = cls.amz_norm_whitespace(val).strip()
-            if (hdr in include or '*' in include or
-                    ('x-amz-*' in include and hdr.startswith('x-amz-') and not
-                    hdr == 'x-amz-client-context')):
+            hdr = makebytes(hdr.strip().lower())
+            val = makebytes(cls.amz_norm_whitespace(val).strip())
+            if (hdr in include or b'*' in include or
+                    (b'x-amz-*' in include and hdr.startswith(b'x-amz-') and not
+                    hdr == b'x-amz-client-context')):
                 vals = cano_headers_dict.setdefault(hdr, [])
                 vals.append(val)
         # Flatten cano_headers dict to string and generate signed_headers
-        cano_headers = ''
+        cano_headers = b''
         signed_headers_list = []
         for hdr in sorted(cano_headers_dict):
             vals = cano_headers_dict[hdr]
-            val = ','.join(sorted(vals))
-            cano_headers += '{}:{}\n'.format(hdr, val)
+            val = b','.join(sorted(vals))
+            cano_headers += hdr + b':' + val + b'\n'
             signed_headers_list.append(hdr)
-        signed_headers = ';'.join(signed_headers_list)
+        signed_headers = b';'.join(signed_headers_list)
         return (cano_headers, signed_headers)
 
     @staticmethod
@@ -599,15 +605,15 @@ class AWS4Auth(AuthBase):
         path -- request path
 
         """
-        safe_chars = '/~'
-        qs = ''
+        safe_chars = b'/~'
+        qs = b''
         fixed_path = path
-        if '?' in fixed_path:
-            fixed_path, qs = fixed_path.split('?', 1)
+        if b'?' in fixed_path:
+            fixed_path, qs = fixed_path.split(b'?', 1)
         fixed_path = posixpath.normpath(fixed_path)
-        fixed_path = re.sub('/+', '/', fixed_path)
-        if path.endswith('/') and not fixed_path.endswith('/'):
-            fixed_path += '/'
+        fixed_path = re.sub(b'/+', b'/', fixed_path)
+        if path.endswith(b'/') and not fixed_path.endswith(b'/'):
+            fixed_path += b'/'
         full_path = fixed_path
         # If Python 2, switch to working entirely in str as quote() has problems
         # with Unicode

--- a/requests_aws4auth/test/requests_aws4auth_test.py
+++ b/requests_aws4auth/test/requests_aws4auth_test.py
@@ -398,7 +398,7 @@ class AWS4Auth_Instantiate_Test(unittest.TestCase):
                         'secret_key',
                         'region',
                         'service')
-        check_set = {'host', 'content-type', 'date', 'x-amz-*'}
+        check_set = {b'host', b'content-type', b'date', b'x-amz-*'}
         self.assertSetEqual(set(auth.include_hdrs), check_set)
 
 


### PR DESCRIPTION
fix for #24 

This PR **DOES NOT WORK YET**. I'm opening it to start a discussion on how we should approach this problem. My current approach seems tedious. There must be a better way.

There are a lot of subtle problems with python3 (the testsuite does not pass yet).
The testsuite passes on python2 (except for `AWS4Auth_GetCanonicalHeaders_Test.test_headers_amz_example` which did not pass before my changes either).

This PR might not be necessary at all if kennethreitz/requests#3573 is fixed. Although there might be more subtleties, because:

``` python
# python 2
>>> x = {u'a': 42, b'b': 42}
>>> b'a' in x
True
>>> u'a' in x
True
>>> b'b' in x
True
>>> u'b' in x
True
```

``` python
# python 3
>>> x = {u'a': 42, b'b': 42}
>>> b'a' in x
False
>>> u'a' in x
True
>>> b'b' in x
True
>>> u'b' in x
False
```

current python3 testsuite output: https://gist.github.com/stefanfoulis/1c9b46a61beba2e6423caa746006cae0
