### PR TITLE
Optimize amz_norm_whitespace

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -671,7 +671,9 @@ class AWS4Auth(AuthBase):
         Ignore text enclosed in quotes.
 
         """
-        return ' '.join(shlex.split(text, posix=False))
+        if re.search('\s', text):
+            return ' '.join(shlex.split(text, posix=False))
+        return text
 
 
 class StrictAWS4Auth(AWS4Auth):


### PR DESCRIPTION
While profiling I noticed that requests-aws4auth spends 2/3 of the time in amz_norm_whitespace while many of the strings that are passed to it don't contain any whitespace. Checking for whitespace using a regex before trying to replace it turned out to be much faster than running shlex every time.