### PR TITLE
Disallow duplicate entries in the default header names collection.

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -172,7 +172,7 @@ class AWS4Auth(AuthBase):
                             supplied directly on the command line
 
     """
-    default_include_headers = ['host', 'content-type', 'date', 'x-amz-*']
+    default_include_headers = {'host', 'content-type', 'date', 'x-amz-*'}
 
     def __init__(self, *args, **kwargs):
         """
@@ -256,7 +256,7 @@ class AWS4Auth(AuthBase):
 
         self.session_token = kwargs.get('session_token')
         if self.session_token:
-            self.default_include_headers.append('x-amz-security-token')
+            self.default_include_headers.add('x-amz-security-token')
         self.include_hdrs = kwargs.get('include_hdrs',
                                        self.default_include_headers)
         AuthBase.__init__(self)


### PR DESCRIPTION
If for whatever reason the initializer of `AWS4Auth` is called more than once with the `session_token` argument provided, the collection class variable will contain duplicates.

Even worse if this happens in an endless loop, e.g. when talking to an elasticsearch cluster. This causes constant memory and CPU consumption growth.

This situation can be easily avoided if we define `AWS4Auth.default_include_headers` as set and not as list.