### PR TITLE
Py38

### DIFF
--- a/requests_aws4auth/test/requests_aws4auth_test.py
+++ b/requests_aws4auth/test/requests_aws4auth_test.py
@@ -172,7 +172,7 @@ def request_from_text(text):
 
     """
     lines = text.splitlines()
-    match = re.search('^([a-z]+) (.*) (http/[0-9]\.[0-9])$', lines[0], re.I)
+    match = re.search(r'^([a-z]+) (.*) (http/[0-9].[0-9])$', lines[0], re.I)
     method, path, version = match.groups()
     headers = {}
     for idx, line in enumerate(lines[1:], start=1):
@@ -799,13 +799,12 @@ class AWS4Auth_GetCanonicalHeaders_Test(unittest.TestCase):
         http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 
         """
-        hdr_text = [
-            'host:iam.amazonaws.com',
-            'Content-type:application/x-www-form-urlencoded; charset=utf-8',
-            'My-header1:    a   b   c ',
-            'x-amz-date:20120228T030031Z',
-            'My-Header2:    "a   b   c"']
-        headers = dict([item.split(':') for item in hdr_text])
+        headers = {
+            'host': 'iam.amazonaws.com',
+            'Content-type': 'application/x-www-form-urlencoded; charset=utf-8',
+            'My-header1': 'a   b   c ',
+            'x-amz-date': '20120228T030031Z',
+            'My-Header2': '"a   b   c"'}
         req = requests.Request('GET',
                                'http://iam.amazonaws.com',
                                headers=headers)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+minversion=1.8.0
+envlist=py{27,35,36,37,38,py,py3}
+skip_missing_interpreters=true
+
+[testenv]
+commands=
+    pytest {posargs} 
+deps=
+    pytest


### PR DESCRIPTION
Update python versions, add tox.ini, fix some tests. Will need to manually update/rebase, and probably tease out the difference in the tests (headers as string+split vs dict).

from sam-washington/requests-aws4auth#38