### PR TITLE
Remove README.md, LICENSE, and HISTORY from package_data.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,7 @@ setup(
     keywords='requests authentication amazon web services aws s3 REST',
     install_requires=['requests', 'six'],
     packages=['requests_aws4auth'],
-    package_data={'requests_aws4auth': ['test/requests_aws4auth_test.py',
-                                        '../README.md', '../LICENSE',
-                                        '../HISTORY.md']},
+    package_data={'requests_aws4auth': ['test/requests_aws4auth_test.py']},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
These were being installed into the top-level of site-packages.

Fixes https://github.com/tedder/requests-aws4auth/issues/51.