### PR TITLE
Feature/httpx support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest requests six
+        pip install flake8 pytest requests httpx six
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -400,6 +400,8 @@ class AWS4Auth(AuthBase):
         if hasattr(req, 'body') and req.body is not None:
             self.encode_body(req)
             content_hash = hashlib.sha256(req.body)
+        elif hasattr(req, 'content') and req.content is not None:
+            content_hash = hashlib.sha256(req.content)
         else:
             content_hash = hashlib.sha256(b'')
         req.headers['x-amz-content-sha256'] = content_hash.hexdigest()

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ setup(
     license='MIT License',
     keywords='requests authentication amazon web services aws s3 REST',
     install_requires=['requests', 'six'],
+    extras_require={
+        'httpx': ['httpx',]
+    },
     packages=['requests_aws4auth'],
     package_data={'requests_aws4auth': ['test/requests_aws4auth_test.py']},
     classifiers=[


### PR DESCRIPTION
Hi, there!

I need to add async api to [sqlalchemy-media](https://github.com/pylover/sqlalchemy-media) using httpx. Particularly, I need to work with a S3 storage.  The library has its own S3 client based on requests and your authentication.

So, I just have made small changes in the places where the authentication interacts with a request object. Particularly, with `url` and `content(data)` properties.

Would it be possible to accept the PR ?