### PR TITLE
Add support for file-like objects as request body

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -398,6 +398,8 @@ class AWS4Auth(AuthBase):
 
         # encode body and generate body hash
         if hasattr(req, 'body') and req.body is not None:
+            if hasattr(req.body, 'read'):
+                req.body = req.body.read()
             self.encode_body(req)
             content_hash = hashlib.sha256(req.body)
         elif hasattr(req, 'content') and req.content is not None:


### PR DESCRIPTION
Requests supports file-like objects as request bodies, and it should be possible to generate the signatures for those types of requests.