### PR TITLE
Prevent unquoting of query string reserved characters

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -704,18 +704,16 @@ class AWS4Auth(AuthBase):
         qs -- querystring
 
         """
-        safe_qs_amz_chars = '&=+'
         safe_qs_unresvd = '-_.~'
         # If Python 2, switch to working entirely in str
         # as quote() has problems with Unicode
         if PY2:
             qs = qs.encode('utf-8')
-            safe_qs_amz_chars = safe_qs_amz_chars.encode()
             safe_qs_unresvd = safe_qs_unresvd.encode()
-        qs = unquote(qs)
         space = b' ' if PY2 else ' '
         qs = qs.split(space)[0]
-        qs = quote(qs, safe=safe_qs_amz_chars)
+        # prevent parse_qs from interpreting semicolon as an alternative delimiter to ampersand
+        qs = qs.replace(';', '%3B')
         qs_items = {}
         for name, vals in parse_qs(qs, keep_blank_values=True).items():
             name = quote(name, safe=safe_qs_unresvd)


### PR DESCRIPTION
Fixes #59.

In `amz_cano_querystring`:
- removed the initial `unquote`/`quote` steps to prevent the introduction of quoted reservered characters
- manually quote semicolons so they aren't interpreted as an alternative delimiter to ampersand by `parse_qs` (AWS doesn't consider them a delimiter and this was previously handled by the `quote` step)

This breaks the `post-vanilla-query-nonunreserved` test in aws_testsuite because `responses` auto-quotes the URL, so in `test_requests_aws4auth.py`:
- undo the URL auto-quoting so that the aws_testsuite URLs are passed in without modification (previously the  `unquote`/`quote` steps temporarily undid the quoting)

Added test cases to cover this issue. All tests pass. including the live tests  (for the endpoints that still exist).