### PR TITLE
Fixes #66 - add MANIFEST.in to include HISTORY.md in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include HISTORY.md


### PR DESCRIPTION
This PR adds a MANIFEST.in that includes HISTORY.md, in order to fix #66.

This can be verified by trying to install the built source tarball, which now works.