### PR TITLE
Remove redundant six dependency and upgrade syntax for Python 3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,15 +19,15 @@ jobs:
         # see versions: https://github.com/actions/python-versions/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest requests httpx six
+        pip install flake8 pytest requests httpx
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -7,9 +7,6 @@ authentication with the Requests module.
 # Licensed under the MIT License:
 # http://opensource.org/licenses/MIT
 
-
-from __future__ import unicode_literals
-
 import hmac
 import hashlib
 import posixpath
@@ -22,14 +19,9 @@ try:
 except ImportError:
     import collections as abc
 
-try:
-    from urllib.parse import urlparse, parse_qs, quote, unquote
-except ImportError:
-    from urlparse import urlparse, parse_qs
-    from urllib import quote, unquote
+from urllib.parse import urlparse, parse_qs, quote, unquote
 
 from requests.auth import AuthBase
-from six import PY2, text_type
 from .aws4signingkey import AWS4SigningKey
 from .exceptions import DateMismatchError, NoSecretKeyError, DateFormatError
 
@@ -548,7 +540,7 @@ class AWS4Auth(AuthBase):
         req -- Requests PreparedRequest object
 
         """
-        if isinstance(req.body, text_type):
+        if isinstance(req.body, str):
             split = req.headers.get('content-type', 'text/plain').split(';')
             if len(split) == 2:
                 ct, cs = split
@@ -678,22 +670,13 @@ class AWS4Auth(AuthBase):
         if path.endswith('/') and not fixed_path.endswith('/'):
             fixed_path += '/'
         full_path = fixed_path
-        # If Python 2, switch to working entirely in str as quote() has problems
-        # with Unicode
-        if PY2:
-            full_path = full_path.encode('utf-8')
-            safe_chars = safe_chars.encode('utf-8')
-            qs = qs.encode('utf-8')
         # S3 seems to require unquoting first. 'host' service is used in
         # amz_testsuite tests
         if self.service in ['s3', 'host']:
             full_path = unquote(full_path)
         full_path = quote(full_path, safe=safe_chars)
         if qs:
-            qm = b'?' if PY2 else '?'
-            full_path = qm.join((full_path, qs))
-        if PY2:
-            full_path = unicode(full_path)
+            full_path = '?'.join((full_path, qs))
         return full_path
 
     @staticmethod
@@ -707,13 +690,7 @@ class AWS4Auth(AuthBase):
 
         """
         safe_qs_unresvd = '-_.~'
-        # If Python 2, switch to working entirely in str
-        # as quote() has problems with Unicode
-        if PY2:
-            qs = qs.encode('utf-8')
-            safe_qs_unresvd = safe_qs_unresvd.encode()
-        space = b' ' if PY2 else ' '
-        qs = qs.split(space)[0]
+        qs = qs.split(' ')[0]
         # prevent parse_qs from interpreting semicolon as an alternative delimiter to ampersand
         qs = qs.replace(';', '%3B')
         qs_items = {}
@@ -727,8 +704,6 @@ class AWS4Auth(AuthBase):
             for val in sorted(vals):
                 qs_strings.append('='.join([name, val]))
         qs = '&'.join(qs_strings)
-        if PY2:
-            qs = unicode(qs)
         return qs
 
     @staticmethod

--- a/requests_aws4auth/aws4signingkey.py
+++ b/requests_aws4auth/aws4signingkey.py
@@ -7,14 +7,10 @@ authentication version 4 signing keys.
 # Licensed under the MIT License:
 # http://opensource.org/licenses/MIT
 
-
-from __future__ import unicode_literals
-
 import hmac
 import hashlib
 from warnings import warn
 from datetime import datetime
-from six import text_type
 
 
 class AWS4SigningKey:
@@ -127,7 +123,7 @@ class AWS4SigningKey:
         msg -- message to sign. unicode or bytes.
 
         """
-        if isinstance(msg, text_type):
+        if isinstance(msg, str):
             msg = msg.encode('utf-8')
         return hmac.new(key, msg, hashlib.sha256).digest()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 import os
-import io
 import codecs
 import re
 from setuptools import setup
 
 
 def read(*names):
-    with io.open(
+    with open(
         os.path.join(os.path.dirname(__file__), *names),
         encoding='utf-8'
     ) as f:
@@ -43,7 +42,7 @@ setup(
     download_url=('https://github.com/tedder/requests-aws4auth/tarball/' + version),
     license='MIT License',
     keywords='requests authentication amazon web services aws s3 REST',
-    install_requires=['requests', 'six'],
+    install_requires=['requests'],
     extras_require={
         'httpx': ['httpx',]
     },


### PR DESCRIPTION
This library no longer supports Python 2 but is still using and installing the six compat library as a dependency.

Let's remove it and use the standard library directly instead.