### PR TITLE
Refactor AWS4Auth init

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Basic usage
 >>> import requests
 >>> from requests_aws4auth import AWS4Auth
 >>> endpoint = 'http://s3-eu-west-1.amazonaws.com'
->>> auth = AWS4Auth('<ACCESS ID>', '<ACCESS KEY>', 'eu-west-1', 's3')
+>>> auth = AWS4Auth(access_id='<ACCESS_ID>', secret_key='<SECRET_KEY>',
+                        region='eu-west-1', service='s3')
 >>> response = requests.get(endpoint, auth=auth)
 >>> response.text
 <?xml version="1.0" encoding="UTF-8"?>
@@ -99,8 +100,9 @@ STS Temporary Credentials
 
 ``` {.sourceCode .python}
 >>> from requests_aws4auth import AWS4Auth
->>> auth = AWS4Auth('<ACCESS ID>', '<ACCESS KEY>', 'eu-west-1', 's3',
-                    session_token='<SESSION TOKEN>')
+>>> auth = AWS4Auth(access_id='<ACCESS_ID>', secret_key='<SECRET_KEY>',
+                        region='eu-west-1', service='s3',
+                        session_token='<SESSION_TOKEN>')
 ...
 ```
 
@@ -117,8 +119,8 @@ Dynamic STS Credentials using botocore RefreshableCredentials
 >>> from requests_aws4auth import AWS4Auth
 >>> from botocore.session import Session
 >>> credentials = Session().get_credentials()
->>> auth = AWS4Auth(region='eu-west-1', service='es',
-                    refreshable_credentials=credentials)
+>>> auth = AWS4Auth(refreshable_credentials=credentials,
+                        region='eu-west-1', service='es')
 ...
 ```
 

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -266,10 +266,8 @@ class AWS4Auth(AuthBase):
 
         self.signing_key = None
 
-        if refreshable_credentials:
+        if refreshable_credentials and region and service:
             # Case 1: Using RefreshableCredentials
-            if not region or not service:
-                raise ValueError("For 'refreshable_credentials' instantiation, 'region' and 'service' must be provided.")
             self.refreshable_credentials = refreshable_credentials
             self.service = service
             self.region = region
@@ -298,8 +296,8 @@ class AWS4Auth(AuthBase):
                 self.date = date
                 self.regenerate_signing_key(secret_key=secret_key)
             else:
-                msg = "Invalid parameters. Must instantiate with one of the three allowed methods."
-                raise ValueError(msg)
+                msg = "Invalid parameters. Must instantiate with one of the three allowed methods: (1) refreshable_credentials, service and region; (2) access_id and signing_key; (3) access_id, secret_key, region, and service."
+                raise TypeError(msg)
         
         assert isinstance(raise_invalid_date, bool), "raise_invalid_date must be a boolean"
         self.raise_invalid_date = raise_invalid_date


### PR DESCRIPTION
Refactor the initialisation of class `AWS4Auth` to use only keyword arguments, this should make it clearer both in the documentation and the code which are the 3 possible ways for authenticating.

This should fix #70.