### PR TITLE
Fix Deprecated datetime.datetime.utcnow()

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.12']
+        python-version: ['3.8', '3.10', '3.12', '3.14']
         # see versions: https://github.com/actions/python-versions/releases/
 
     steps:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
+1.3.2 (2026-05-01)
+=========
+
+**Changes**
+
+- Fix Deprecated datetime.datetime.utcnow(), #77 #78. Thanks @andercarrera.
+- Unit test and integration test updates, #78.
+
+
 1.3.1 (2024-07-21)
 =========
 

--- a/requests_aws4auth/__init__.py
+++ b/requests_aws4auth/__init__.py
@@ -199,4 +199,4 @@ del aws4auth
 del aws4signingkey
 del exceptions
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -7,12 +7,12 @@ authentication with the Requests module.
 # Licensed under the MIT License:
 # http://opensource.org/licenses/MIT
 
-import hmac
+import datetime
 import hashlib
+import hmac
 import posixpath
 import re
 import shlex
-import datetime
 
 try:
     import collections.abc as abc
@@ -381,7 +381,7 @@ class AWS4Auth(AuthBase):
             # replace them with x-amz-header with current date and time
             if 'date' in req.headers: del req.headers['date']
             if 'x-amz-date' in req.headers: del req.headers['x-amz-date']
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(datetime.UTC)
             req_date = now.date()
             req.headers['x-amz-date'] = now.strftime('%Y%m%dT%H%M%SZ')
         req_scope_date = req_date.strftime('%Y%m%d')

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -381,7 +381,7 @@ class AWS4Auth(AuthBase):
             # replace them with x-amz-header with current date and time
             if 'date' in req.headers: del req.headers['date']
             if 'x-amz-date' in req.headers: del req.headers['x-amz-date']
-            now = datetime.datetime.now(datetime.UTC)
+            now = datetime.datetime.now(datetime.timezone.utc)
             req_date = now.date()
             req.headers['x-amz-date'] = now.strftime('%Y%m%dT%H%M%SZ')
         req_scope_date = req_date.strftime('%Y%m%d')

--- a/requests_aws4auth/aws4signingkey.py
+++ b/requests_aws4auth/aws4signingkey.py
@@ -10,7 +10,7 @@ authentication version 4 signing keys.
 import hmac
 import hashlib
 from warnings import warn
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class AWS4SigningKey:
@@ -82,7 +82,7 @@ class AWS4SigningKey:
 
         self.region = region
         self.service = service
-        self.date = date or datetime.utcnow().strftime('%Y%m%d')
+        self.date = date or datetime.now(timezone.utc).strftime('%Y%m%d')
         self.scope = '{}/{}/{}/aws4_request'.format(self.date, self.region, self.service)
         self.store_secret_key = store_secret_key
         self.secret_key = secret_key if self.store_secret_key else None

--- a/requests_aws4auth/test/test_live.py
+++ b/requests_aws4auth/test/test_live.py
@@ -18,9 +18,10 @@ The live tests perform information retrieval operations only, no chargeable
 operations are performed!
 """
 
-import unittest
-import os
 import json
+import os
+import unittest
+from datetime import UTC
 
 live_access_id = os.getenv('AWS_ACCESS_ID')
 live_secret_key = os.getenv('AWS_ACCESS_KEY')
@@ -206,7 +207,7 @@ class AWS4Auth_LiveService_Test(unittest.TestCase):
         url = 'https://mobileanalytics.us-east-1.amazonaws.com/2014-06-05/events'
         service = 'mobileanalytics'
         region = 'us-east-1'
-        dt = datetime.datetime.utcnow()
+        dt = datetime.datetime.now(UTC)
         date = dt.strftime('%Y%m%d')
         sig_key = AWS4SigningKey(live_secret_key, region, service, date)
         auth = AWS4Auth(live_access_id, sig_key)

--- a/requests_aws4auth/test/test_live.py
+++ b/requests_aws4auth/test/test_live.py
@@ -21,7 +21,7 @@ operations are performed!
 import json
 import os
 import unittest
-from datetime import UTC
+import datetime
 
 live_access_id = os.getenv('AWS_ACCESS_ID')
 live_secret_key = os.getenv('AWS_ACCESS_KEY')
@@ -207,7 +207,7 @@ class AWS4Auth_LiveService_Test(unittest.TestCase):
         url = 'https://mobileanalytics.us-east-1.amazonaws.com/2014-06-05/events'
         service = 'mobileanalytics'
         region = 'us-east-1'
-        dt = datetime.datetime.now(UTC)
+        dt = datetime.datetime.now(datetime.timezone.utc)
         date = dt.strftime('%Y%m%d')
         sig_key = AWS4SigningKey(live_secret_key, region, service, date)
         auth = AWS4Auth(live_access_id, sig_key)

--- a/requests_aws4auth/test/test_live.py
+++ b/requests_aws4auth/test/test_live.py
@@ -23,6 +23,11 @@ import os
 import unittest
 import datetime
 
+import requests
+
+from requests_aws4auth import AWS4Auth
+from requests_aws4auth.aws4signingkey import AWS4SigningKey
+
 live_access_id = os.getenv('AWS_ACCESS_ID')
 live_secret_key = os.getenv('AWS_ACCESS_KEY')
 
@@ -196,7 +201,13 @@ class AWS4Auth_LiveService_Test(unittest.TestCase):
         service = path_qs.split('.')[0]
         url = 'https://' + path_qs
         region = 'us-east-1'
-        auth = AWS4Auth(live_access_id, live_secret_key, region, service)
+        auth = AWS4Auth(
+            live_access_id,
+            live_secret_key,
+            region,
+            service,
+            session_token=os.getenv('AWS_SESSION_TOKEN'),
+        )
         response = requests.request(method, url, auth=auth,
                                     data=body, headers=headers)
         # suppress socket close warnings
@@ -210,7 +221,11 @@ class AWS4Auth_LiveService_Test(unittest.TestCase):
         dt = datetime.datetime.now(datetime.timezone.utc)
         date = dt.strftime('%Y%m%d')
         sig_key = AWS4SigningKey(live_secret_key, region, service, date)
-        auth = AWS4Auth(live_access_id, sig_key)
+        auth = AWS4Auth(
+            live_access_id,
+            sig_key,
+            session_token=os.getenv('AWS_SESSION_TOKEN'),
+        )
         headers = {'Content-Type': 'application/json',
                    'X-Amz-Date': dt.strftime('%Y%m%dT%H%M%SZ'),
                    'X-Amz-Client-Context':

--- a/requests_aws4auth/test/test_requests_aws4auth.py
+++ b/requests_aws4auth/test/test_requests_aws4auth.py
@@ -24,23 +24,23 @@ cases covered by the suite will be missed.
 # Licensed under the MIT License:
 # http://opensource.org/licenses/MIT
 
-import os
-import unittest
-import re
+import datetime
 import hashlib
 import itertools
+import os
+import re
+import unittest
 import warnings
-import datetime
 from errno import ENOENT
-
 from urllib.parse import quote, urlparse, urlunparse
 
-import requests
 import httpx
+import requests
 
 from requests_aws4auth import AWS4Auth
 from requests_aws4auth.aws4signingkey import AWS4SigningKey
 from requests_aws4auth.exceptions import DateFormatError, NoSecretKeyError
+
 
 class SimpleNamespace:
     pass
@@ -196,10 +196,10 @@ class AWS4_SigningKey_Test(unittest.TestCase):
         self.assertEqual(obj.secret_key, 'secret_key')
 
     def test_date(self):
-        test_date = datetime.datetime.utcnow().strftime('%Y%m%d')
+        test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
         obj = AWS4SigningKey('secret_key', 'region', 'service')
         if obj.date != test_date:
-            test_date = datetime.datetime.utcnow().strftime('%Y%m%d')
+            test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
         self.assertEqual(obj.date, test_date)
 
     def test_amz_date(self):
@@ -209,10 +209,10 @@ class AWS4_SigningKey_Test(unittest.TestCase):
         """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            test_date = datetime.datetime.utcnow().strftime('%Y%m%d')
+            test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
             obj = AWS4SigningKey('secret_key', 'region', 'service')
             if obj.amz_date != test_date:
-                test_date = datetime.datetime.utcnow().strftime('%Y%m%d')
+                test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
             self.assertEqual(obj.amz_date, test_date)
 
     def test_amz_date_warning(self):
@@ -315,7 +315,7 @@ class AWS4_SigningKey_Test(unittest.TestCase):
 class AWS4Auth_Instantiate_Test(unittest.TestCase):
 
     def test_instantiate_from_args(self):
-        test_date = datetime.datetime.utcnow().strftime('%Y%m%d')
+        test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
         test_inc_hdrs = {'a', 'b', 'c'}
         auth = AWS4Auth('access_id',
                         'secret_key',
@@ -334,7 +334,7 @@ class AWS4Auth_Instantiate_Test(unittest.TestCase):
         self.assertEqual(auth.signing_key.region, 'region')
         self.assertEqual(auth.signing_key.service, 'service')
         if test_date != auth.signing_key.date:
-            test_date = datetime.datetime.utcnow().strftime('%Y%m%d')
+            test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
         self.assertEqual(auth.signing_key.date, test_date)
         expected = '{}/region/service/aws4_request'.format(test_date)
         self.assertEqual(auth.signing_key.scope, expected)

--- a/requests_aws4auth/test/test_requests_aws4auth.py
+++ b/requests_aws4auth/test/test_requests_aws4auth.py
@@ -196,10 +196,10 @@ class AWS4_SigningKey_Test(unittest.TestCase):
         self.assertEqual(obj.secret_key, 'secret_key')
 
     def test_date(self):
-        test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
+        test_date = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d')
         obj = AWS4SigningKey('secret_key', 'region', 'service')
         if obj.date != test_date:
-            test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
+            test_date = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d')
         self.assertEqual(obj.date, test_date)
 
     def test_amz_date(self):
@@ -209,10 +209,10 @@ class AWS4_SigningKey_Test(unittest.TestCase):
         """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
+            test_date = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d')
             obj = AWS4SigningKey('secret_key', 'region', 'service')
             if obj.amz_date != test_date:
-                test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
+                test_date = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d')
             self.assertEqual(obj.amz_date, test_date)
 
     def test_amz_date_warning(self):
@@ -315,7 +315,7 @@ class AWS4_SigningKey_Test(unittest.TestCase):
 class AWS4Auth_Instantiate_Test(unittest.TestCase):
 
     def test_instantiate_from_args(self):
-        test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
+        test_date = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d')
         test_inc_hdrs = {'a', 'b', 'c'}
         auth = AWS4Auth('access_id',
                         'secret_key',
@@ -334,7 +334,7 @@ class AWS4Auth_Instantiate_Test(unittest.TestCase):
         self.assertEqual(auth.signing_key.region, 'region')
         self.assertEqual(auth.signing_key.service, 'service')
         if test_date != auth.signing_key.date:
-            test_date = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')
+            test_date = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d')
         self.assertEqual(auth.signing_key.date, test_date)
         expected = '{}/region/service/aws4_request'.format(test_date)
         self.assertEqual(auth.signing_key.scope, expected)


### PR DESCRIPTION
also:
- fix additional deprecation warnings for UTC
- ensure pre-py311 compat
- update workflow py versions
- use session token for live tests