### PR TITLE
fix: sign the Host header that is actually sent

### DIFF
--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -401,6 +401,12 @@ class AWS4Auth(AuthBase):
         req.headers['x-amz-content-sha256'] = content_hash.hexdigest()
         if self.session_token:
             req.headers['x-amz-security-token'] = self.session_token
+        # Pin the Host header rather than leaving it to be generated at send
+        # time. Signing a value the client then disagrees with is what caused
+        # #34/#65/#79; setting it here makes the signed value and the sent
+        # value the same string by construction.
+        if 'host' not in req.headers:
+            req.headers['host'] = self.get_host_header(req.url)
 
         # generate signature
         result = self.get_canonical_headers(req, self.include_hdrs)
@@ -580,6 +586,42 @@ class AWS4Auth(AuthBase):
         cano_req = '\n'.join(req_parts)
         return cano_req
 
+    @staticmethod
+    def get_host_header(url):
+        """
+        Return the Host header value that will be sent for this URL.
+
+        Requests doesn't put a Host header on a PreparedRequest; the header is
+        generated later, when the request is sent. AWS requires host to be
+        signed, so it has to be computed here, and it has to match what is
+        eventually sent or the service will compute a different signature and
+        reject the request.
+
+        Python's http.client only includes the port when it is not the default
+        for the scheme (see http.client.HTTPConnection.putrequest). Note that
+        "default" is scheme-dependent: 443 is default for https but not for
+        http, so http://host:443 keeps its port on the wire. IPv6 literals are
+        bracketed and contain colons, so the port cannot be found by splitting
+        on the first colon.
+
+        """
+        parsed = urlparse(str(url))
+        netloc = parsed.netloc
+        # Credentials are part of netloc but are not sent in the Host header.
+        if '@' in netloc:
+            netloc = netloc.rsplit('@', 1)[1]
+        try:
+            port = parsed.port
+        except ValueError:
+            # Not a usable port. Leave the netloc alone and let the HTTP
+            # client reject the URL when it tries to connect, which is what
+            # happens today.
+            return netloc
+        if ((port == 80 and parsed.scheme == 'http')
+                or (port == 443 and parsed.scheme == 'https')):
+            netloc = netloc.rsplit(':', 1)[0]
+        return netloc
+
     @classmethod
     def get_canonical_headers(cls, req, include=None):
         """
@@ -607,7 +649,7 @@ class AWS4Auth(AuthBase):
         # in the signed headers, but Requests doesn't include it in a
         # PreparedRequest
         if 'host' not in headers:
-            headers['host'] = urlparse(str(req.url)).netloc.split(':')[0]
+            headers['host'] = cls.get_host_header(req.url)
         # Aggregate for upper/lowercase header name collisions in header names,
         # AMZ requires values of colliding headers be concatenated into a
         # single header with lowercase name.  Although this is not possible with

--- a/requests_aws4auth/test/test_integration.py
+++ b/requests_aws4auth/test/test_integration.py
@@ -101,6 +101,22 @@ class S3CompatibleEndpoint_Test(unittest.TestCase):
         self.assertSignatureAccepted(h.status_code, h.text)
         self.assertEqual(r.status_code, h.status_code)
 
+    def test_credentials_in_url_still_accepted(self):
+        """
+        Credentials in the URL are part of the netloc but are not sent in the
+        Host header. Signing them, or signing only the part before the first
+        colon, both produce a signature the server rejects.
+
+        Passing auth= means requests ignores the URL credentials for
+        authentication, so these only affect how the host is derived.
+
+        """
+        from urllib.parse import urlparse
+        parsed = urlparse(endpoint)
+        url = '{}://user:pass@{}/'.format(parsed.scheme, parsed.netloc)
+        response = requests.get(url, auth=self.auth())
+        self.assertSignatureAccepted(response.status_code, response.text)
+
     def test_explicit_host_header_still_accepted(self):
         """
         Setting Host explicitly is the documented workaround for the bug and

--- a/requests_aws4auth/test/test_requests_aws4auth.py
+++ b/requests_aws4auth/test/test_requests_aws4auth.py
@@ -943,9 +943,13 @@ class AWS4Auth_GetCanonicalHeaders_Test(unittest.TestCase):
         """
         The Host header is not part of the prepared request, but generated
         later, and the port is kept in the header if it is not the standard
-        HTTPS port. d190dcb has a bug that also strips non-standard ports from
-        the signature, causing signature and host header to mismatch. This is a
-        regression test for that bug.
+        HTTPS port. The signature has to keep it too, or it will not match the
+        request that gets sent.
+
+        This assertion was inverted when it was added in #68: it asserted the
+        signature did *not* match the wire, documenting the bug rather than
+        testing the behaviour, while its httpx twin below asserted the
+        opposite for the same URL.
 
         """
         req = requests.Request('GET', 'https://amazonaws.com:8443')
@@ -954,7 +958,7 @@ class AWS4Auth_GetCanonicalHeaders_Test(unittest.TestCase):
         result = AWS4Auth.get_canonical_headers(preq, include=['host'])
         cano_hdrs, signed_hdrs = result
         expected = 'host:amazonaws.com:8443\n'
-        self.assertNotEqual(cano_hdrs, expected)
+        self.assertEqual(cano_hdrs, expected)
 
     def test_netloc_port_is_stripped_for_standard_port_using_httpx(self):
         """
@@ -1015,9 +1019,16 @@ def wire_host_header(url):
             pass
 
     parsed = urlparse(url)
+    netloc = parsed.netloc
+    # requests pulls credentials out of the URL and turns them into an auth
+    # header, so the connection -- and therefore the Host header -- never sees
+    # them. Model that here. test_requests_strips_credentials_from_host_header
+    # below checks this against a real socket rather than trusting it.
+    if '@' in netloc:
+        netloc = netloc.rsplit('@', 1)[1]
     conn_cls = (http.client.HTTPSConnection if parsed.scheme == 'https'
                 else http.client.HTTPConnection)
-    conn = conn_cls(parsed.netloc)
+    conn = conn_cls(netloc)
     conn.sock = CaptureSocket()
     conn.putrequest('GET', '/')
     conn.endheaders()
@@ -1043,6 +1054,11 @@ HOST_HEADER_URLS = [
     'https://[::1]:8443',
     'https://[::1]:443',
     'https://[::1]',
+    # Credentials live in the netloc but are never sent in the Host header.
+    'https://user:pass@amazonaws.com:8443',
+    'https://user:pass@amazonaws.com:443',
+    'https://user:pass@amazonaws.com',
+    'http://user@amazonaws.com:7480',
 ]
 
 
@@ -1104,6 +1120,50 @@ class AWS4Auth_HostHeaderMatchesWire_Test(unittest.TestCase):
                 preq = requests.Request('GET', url,
                                         headers={'Host': host}).prepare()
                 self.assertEqual(self.canonical_host(preq), host)
+
+    def test_requests_strips_credentials_from_host_header(self):
+        """
+        Credentials in the URL are part of the netloc but are not sent in the
+        Host header, so they must not be signed either. This checks the real
+        behaviour against a socket rather than trusting the oracle's model of
+        it, since http.client on its own will happily build a Host header
+        containing the credentials if handed a netloc with them in.
+
+        Note the old code signed 'user' here (everything before the first
+        colon), and 8e1417c would have signed 'user:pass@amazonaws.com:8443'.
+        Neither matches what is sent.
+
+        """
+        import threading
+        import http.server
+
+        received = {}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                received['host'] = self.headers.get('Host')
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'ok')
+
+            def log_message(self, *args):
+                pass
+
+        server = http.server.HTTPServer(('127.0.0.1', 0), Handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            url = 'http://user:pass@127.0.0.1:{}/'.format(port)
+            auth = AWS4Auth('id', 'secret', 'us-east-1', 's3')
+            requests.get(url, auth=auth)
+            self.assertEqual(received['host'], '127.0.0.1:{}'.format(port))
+            # What we sign has to be what the server saw.
+            preq = requests.Request('GET', url).prepare()
+            self.assertEqual(self.canonical_host(preq), received['host'])
+        finally:
+            server.shutdown()
+            server.server_close()
 
     def test_malformed_ports_are_rejected_before_signing(self):
         """


### PR DESCRIPTION
The Host header was signed with the port stripped unconditionally, while the request going out keeps the port whenever it is not the default for the scheme. The two disagreed, so the service computed a different signature and rejected the request with SignatureDoesNotMatch.

This is #79, and before it #34. It was fixed once in 8e1417c (#63) and reverted in b328b86 after #65 reported a regression.

Two changes, which together make the divergence unrepresentable:

- get_host_header() computes the value the client will send: strip the port only when it is the default for that scheme. 443 is default for https but not for http, so http://host:443 keeps its port. IPv6 literals are no longer split on their first colon, which previously reduced https://[::1] to a single "[" regardless of any port. Credentials are stripped, since they sit in the netloc but are never sent in the Host header -- the old code signed everything before the first colon ('user'), and 8e1417c would have signed them along with the port. Neither matches the wire.

- __call__ now sets the Host header instead of only signing it. The wire value is byte-identical either way, but signed value and sent value become the same string, so they cannot drift apart again if urllib3 ever changes how it derives the header.

Verified against real SigV4 implementations on non-default ports, which is something AWS itself cannot test: every AWS endpoint is on 443, so this code path is unreachable there. RadosGW on 7480 and MinIO on 9111 both reject the old signature and accept the new one. Real AWS S3 is unaffected, including URLs with an explicit :443.

The host header table gains the credential-bearing URL shapes, and a new test checks them against a real socket rather than trusting the oracle: the oracle models requests stripping credentials before it opens the connection, and that model should itself be tested. Without the fix it reports "AssertionError: 'user' != '127.0.0.1:52809'".

Also flips the assertion added in #68, which was inverted: it asserted the signature did not match the wire, documenting the bug rather than testing the behaviour, while its httpx twin asserted the opposite for the same URL.

Fixes #79
Fixes #34


Claude-Session: https://claude.ai/code/session_01GKqoiAcwVRjYpwpDKcPqDQ